### PR TITLE
feat: :compile_auto_inspect and :auto_inspect options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v0.8.0
+* `:compile_auto_inspect` and `:auto_inspect` config options, both default
+  to false
+* Added `Scribe.auto_inspect/1` for toggling auto inspect
+* Added `Scribe.auto_inspect?/0`
+* Removed `Scribe.enable/0` and `Scribe.disable/0`, replaced with above
+* Removed `Scribe.enabled?/0`, replaced with above
+
+To work with production releases, auto-inspect functionality can now be
+optionally compiled (not compiled by default). To enable auto-inspect for
+your development environment, add this to your `config/dev.exs`:
+
+    config :scribe,
+      compile_auto_inspect: true,
+      auto_inspect: true
+
+To temporarily disable auto-inspect in your shell, use
+`Scribe.auto_inspect(false)`. Inspect will work as normal until set to
+true again.
+
+If auto-inspect is not compiled (or disabled), `Scribe.print/2` and similar
+functions will continue to work as normal.
+
 # v0.7.0
 * Pseudographics style added
 

--- a/README.md
+++ b/README.md
@@ -13,77 +13,88 @@ Pretty-print tables of Elixir structs and maps. Inspired by [hirb](https://githu
   ```elixir
   def deps do
     [
-      {:scribe, "~> 0.7"}
+      {:scribe, "~> 0.8"}
     ]
   end
   ```
 
 ## Usage
 
-Scribe overrides `Inspect` to automatically print a list of maps or structs
-as a table. Header columns are taken from the keys of the first element.
+Use `Scribe.print/1` to print a list of maps or structs as a table.
+Header columns are taken from the keys of the first element.
 
-```elixir
-iex(1)> [%{key: "value", another_key: 123}, %{key: "test", another_key: :key}]
-+----------------+-------------+
-| :another_key   | :key        |
-+----------------+-------------+
-| 123            | "value"     |
-| :key           | "test"      |
-+----------------+-------------+
-```
+  ```elixir
+  iex(1)> [%{key: "value", another_key: 123},
+  ...(1)> %{key: "test", another_key: :key}] |> Scribe.print
+  +----------------+-------------+
+  | :another_key   | :key        |
+  +----------------+-------------+
+  | 123            | "value"     |
+  | :key           | "test"      |
+  +----------------+-------------+
+  ```
 
-Useful for printing large collections, such as results of Ecto queries
-```elixir
+Useful for printing large collections, such as results of database queries
+
+  ```elixir
 # %User{id: nil, email: nil}
 
-iex(1)> User |> limit(5) |> Repo.all
-+-------------+----------------------------+------+
-| :__struct__ | :email                     | :id  |
-+-------------+----------------------------+------+
-| User        | "myles_fisher@beahan.com"  | 5171 |
-| User        | "dawson_bartell@lynch.org" | 4528 |
-| User        | "hassan1972@langworth.com" | 1480 |
-| User        | "kiera.schulist@koch.com"  | 2084 |
-| User        | "cynthia1970@mann.name"    | 6599 |
-+-------------+----------------------------+------+
-```
+  iex(1)> User |> limit(5) |> Repo.all |> Scribe.print
+  +-------------+----------------------------+------+
+  | :__struct__ | :email                     | :id  |
+  +-------------+----------------------------+------+
+  | User        | "myles_fisher@beahan.com"  | 5171 |
+  | User        | "dawson_bartell@lynch.org" | 4528 |
+  | User        | "hassan1972@langworth.com" | 1480 |
+  | User        | "kiera.schulist@koch.com"  | 2084 |
+  | User        | "cynthia1970@mann.name"    | 6599 |
+  +-------------+----------------------------+------+
+  ```
 
-Need to disable Scribe by default?
-```elixir
-# config.exs
-config :scribe, enable: false
-```
+## Use Scribe Automatically
 
-Or do it dynamically in the shell...
-```elixir
-iex(1)> Scribe.disable
-iex(2)> %{id: 1234, key: :value}
-%{id: 1234, key: :value}
-```
+Scribe can override `inspect/2` to automatically return maps in table format.
+Add the following to your `config/dev.exs`:
+
+  ```elixir
+  config :scribe,
+    compile_auto_inspect: true,
+    auto_inspect: true
+  ```
+
+If needed, it can be temporarily disabled in the shell.
+
+  ```elixir
+  iex(1)> Scribe.auto_inspect(false)
+  iex(2)> %{id: 1234, key: :value}
+  %{id: 1234, key: :value}
+  ```
+
+*Note: Auto-inspect functionality will not work in production Distillery
+releases. Leave it out of your prod.exs*
 
 ## Pagination
 
 Scribe uses [pane](https://github.com/codedge-llc/pane) to paginate large tables.
 Use with `Scribe.console/2`.
 
-```elixir
-# %User{id: nil, email: nil, first_name: nil, last_name: nil}
-iex(1)> User |> limit(5) |> Repo.all |> Scribe.console
+  ```elixir
+  # %User{id: nil, email: nil, first_name: nil, last_name: nil}
+  iex(1)> User |> limit(5) |> Repo.all |> Scribe.console
 
-+-------------+------------------------+-------------+-------+------------+
-| :__struct__ | :email                 | :first_name | :id   | :last_name |
-+-------------+------------------------+-------------+-------+------------+
-| User        | "celestine_satterfield | "Gene"      | 9061  | "Krajcik"  |
-| User        | "lynn1978@bednar.org"  | "Maeve"     | 9865  | "Gerlach"  |
-| User        | "melisa1975@hilll.biz" | "Theodora"  | 2262  | "Wunsch"   |
-| User        | "furman.grady@ryan.org | "Oswaldo"   | 4977  | "Simonis"  |
-| User        | "caesar_hirthe@reynold | "Arjun"     | 3907  | "Prohaska" |
-+-------------+------------------------+-------------+-------+------------+
+  +-------------+------------------------+-------------+-------+------------+
+  | :__struct__ | :email                 | :first_name | :id   | :last_name |
+  +-------------+------------------------+-------------+-------+------------+
+  | User        | "celestine_satterfield | "Gene"      | 9061  | "Krajcik"  |
+  | User        | "lynn1978@bednar.org"  | "Maeve"     | 9865  | "Gerlach"  |
+  | User        | "melisa1975@hilll.biz" | "Theodora"  | 2262  | "Wunsch"   |
+  | User        | "furman.grady@ryan.org | "Oswaldo"   | 4977  | "Simonis"  |
+  | User        | "caesar_hirthe@reynold | "Arjun"     | 3907  | "Prohaska" |
+  +-------------+------------------------+-------------+-------+------------+
 
 
-[1 of 1] (j)next (k)prev (q)quit
-```
+  [1 of 1] (j)next (k)prev (q)quit
+  ```
 
 ## Printing Custom Tables
 
@@ -91,72 +102,73 @@ iex(1)> User |> limit(5) |> Repo.all |> Scribe.console
 customize output. You can use either the atom key or customize the header
 with `{"Custom Title", :key}`.
 
-```elixir
-# %User{id: nil, email: nil, first_name: nil, last_name: nil}
+  ```elixir
+  # %User{id: nil, email: nil, first_name: nil, last_name: nil}
 
-User
-|> limit(5)
-|> Repo.all
-|> Scribe.print(data: [{"ID", :id}, :first_name, :last_name])
+  User
+  |> limit(5)
+  |> Repo.all
+  |> Scribe.print(data: [{"ID", :id}, :first_name, :last_name])
 
-+------+--------------+-------------+
-| "ID" | :first_name  | :last_name  |
-+------+--------------+-------------+
-| 9061 | "Gene"       | "Krajcik"   |
-| 9865 | "Maeve"      | "Gerlach"   |
-| 2262 | "Theodora"   | "Wunsch"    |
-| 4977 | "Oswaldo"    | "Simonis"   |
-| 3907 | "Arjun"      | "Prohaska"  |
-+------+--------------+-------------+
-```
+  +------+--------------+-------------+
+  | "ID" | :first_name  | :last_name  |
+  +------+--------------+-------------+
+  | 9061 | "Gene"       | "Krajcik"   |
+  | 9865 | "Maeve"      | "Gerlach"   |
+  | 2262 | "Theodora"   | "Wunsch"    |
+  | 4977 | "Oswaldo"    | "Simonis"   |
+  | 3907 | "Arjun"      | "Prohaska"  |
+  +------+--------------+-------------+
+  ```
 
 ### Function Columns
 
 You can specify functions that take the given row's struct or map as its only argument.
-```elixir
-# %User{id: nil, email: nil, first_name: nil, last_name: nil}
-results =
-  User
-  |> limit(5)
-  |> Repo.all
-  |> Scribe.print(u, [{"ID", :id}, {"Full Name", fn(x) -> "#{x.last_name}, #{x.first_name}" end}])
+  ```elixir
+  # %User{id: nil, email: nil, first_name: nil, last_name: nil}
+  results =
+    User
+    |> limit(5)
+    |> Repo.all
+    |> Scribe.print(u, [{"ID", :id}, {"Full Name", fn(x) -> "#{x.last_name}, #{x.first_name}" end}])
 
-+--------------------------+----------------------------------------------+
-| "ID"                     | "Full Name"                                  |
-+--------------------------+----------------------------------------------+
-| 9061                     | "Krajcik, Gene"                              |
-| 9865                     | "Gerlach, Maeve"                             |
-| 2262                     | "Wunsch, Theodora"                           |
-| 4977                     | "Simonis, Oswaldo"                           |
-| 3907                     | "Prohaska, Arjun"                            |
-+--------------------------+----------------------------------------------+
+  +--------------------------+----------------------------------------------+
+  | "ID"                     | "Full Name"                                  |
+  +--------------------------+----------------------------------------------+
+  | 9061                     | "Krajcik, Gene"                              |
+  | 9865                     | "Gerlach, Maeve"                             |
+  | 2262                     | "Wunsch, Theodora"                           |
+  | 4977                     | "Simonis, Oswaldo"                           |
+  | 3907                     | "Prohaska, Arjun"                            |
+  +--------------------------+----------------------------------------------+
 
-:ok
-```
+  :ok
+  ```
 
 ## Styling Options
 
 ### Width
 
 Pass a `width` option to define table width.
-```elixir
-iex> Scribe.print(data, width: 80)
+  ```elixir
+  iex> Scribe.print(data, width: 80)
 
-+-------------------+-----------------------------------------------------+
-| :id               | :key                                                |
-+-------------------+-----------------------------------------------------+
-| 910               | "B1786AC67B4DEB19"                                  |
-| 313               | "30CB8A2DE4750070"                                  |
-| 25                | "D0859205FC7E7298"                                  |
-| 647               | "8F0060AD0BD6AB04"                                  |
-| 253               | "65509A684D619182"                                  |
-+-------------------+-----------------------------------------------------+
-```
+  +-------------------+-----------------------------------------------------+
+  | :id               | :key                                                |
+  +-------------------+-----------------------------------------------------+
+  | 910               | "B1786AC67B4DEB19"                                  |
+  | 313               | "30CB8A2DE4750070"                                  |
+  | 25                | "D0859205FC7E7298"                                  |
+  | 647               | "8F0060AD0BD6AB04"                                  |
+  | 253               | "65509A684D619182"                                  |
+  +-------------------+-----------------------------------------------------+
+  ```
 
 ### Disable Colors
-```elixir
-iex> Scribe.print(data, colorization: false)
-```
+
+  ```elixir
+  iex> Scribe.print(data, colorization: false)
+  ```
 
 ### Styles
 
@@ -164,62 +176,66 @@ Scribe supports three styling formats natively, with support for custom adapters
 
 *Default*
 
-```elixir
-iex> Scribe.print(data, style: Scribe.Style.Default)
+  ```elixir
+  iex> Scribe.print(data, style: Scribe.Style.Default)
 
-+-------+-----------------------------------+------------------------+
-| :id   | :inserted_at                      | :key                   |
-+-------+-----------------------------------+------------------------+
-| 457   | "2017-03-27 14:42:34.095202Z"     | "CEB0E055ECDF6028"     |
-| 326   | "2017-03-27 14:42:34.097519Z"     | "CF67027F7235B88D"     |
-| 756   | "2017-03-27 14:42:34.097553Z"     | "DE016DFF477BEDDB"     |
-| 484   | "2017-03-27 14:42:34.097572Z"     | "9194A82EF4BB0123"     |
-| 780   | "2017-03-27 14:42:34.097591Z"     | "BF92748B4AAAF14A"     |
-+-------+-----------------------------------+------------------------+
-```
+  +-------+-----------------------------------+------------------------+
+  | :id   | :inserted_at                      | :key                   |
+  +-------+-----------------------------------+------------------------+
+  | 457   | "2017-03-27 14:42:34.095202Z"     | "CEB0E055ECDF6028"     |
+  | 326   | "2017-03-27 14:42:34.097519Z"     | "CF67027F7235B88D"     |
+  | 756   | "2017-03-27 14:42:34.097553Z"     | "DE016DFF477BEDDB"     |
+  | 484   | "2017-03-27 14:42:34.097572Z"     | "9194A82EF4BB0123"     |
+  | 780   | "2017-03-27 14:42:34.097591Z"     | "BF92748B4AAAF14A"     |
+  +-------+-----------------------------------+------------------------+
+  ```
 
 *Psql*
 
-```elixir
-iex> Scribe.print(data, style: Scribe.Style.Psql)
+  ```elixir
+  iex> Scribe.print(data, style: Scribe.Style.Psql)
 
- :id   | :inserted_at                      | :key
--------+-----------------------------------+------------------------
- 700   | "2017-03-27 14:41:33.411442Z"     | "A2FA80D0F6DF9388"
- 890   | "2017-03-27 14:41:33.412955Z"     | "F95094328A91D950"
- 684   | "2017-03-27 14:41:33.412991Z"     | "1EAC6B28045ED644"
- 531   | "2017-03-27 14:41:33.413015Z"     | "DC2377B696355642"
- 648   | "2017-03-27 14:41:33.413037Z"     | "EA9311B4683A52B3"
-```
+   :id   | :inserted_at                      | :key
+  -------+-----------------------------------+------------------------
+   700   | "2017-03-27 14:41:33.411442Z"     | "A2FA80D0F6DF9388"
+   890   | "2017-03-27 14:41:33.412955Z"     | "F95094328A91D950"
+   684   | "2017-03-27 14:41:33.412991Z"     | "1EAC6B28045ED644"
+   531   | "2017-03-27 14:41:33.413015Z"     | "DC2377B696355642"
+   648   | "2017-03-27 14:41:33.413037Z"     | "EA9311B4683A52B3"
+  ```
 
 *Github Markdown*
 
-```elixir
-iex> Scribe.print(data, style: Scribe.Style.GithubMarkdown)
+  ```elixir
+  iex> Scribe.print(data, style: Scribe.Style.GithubMarkdown)
 
-| :id   | :inserted_at                      | :key                   |
-|-------|-----------------------------------|------------------------|
-| 457   | "2017-03-27 14:42:34.095202Z"     | "CEB0E055ECDF6028"     |
-| 326   | "2017-03-27 14:42:34.097519Z"     | "CF67027F7235B88D"     |
-| 756   | "2017-03-27 14:42:34.097553Z"     | "DE016DFF477BEDDB"     |
-| 484   | "2017-03-27 14:42:34.097572Z"     | "9194A82EF4BB0123"     |
-| 780   | "2017-03-27 14:42:34.097591Z"     | "BF92748B4AAAF14A"     |
-```
+  | :id   | :inserted_at                      | :key                   |
+  |-------|-----------------------------------|------------------------|
+  | 457   | "2017-03-27 14:42:34.095202Z"     | "CEB0E055ECDF6028"     |
+  | 326   | "2017-03-27 14:42:34.097519Z"     | "CF67027F7235B88D"     |
+  | 756   | "2017-03-27 14:42:34.097553Z"     | "DE016DFF477BEDDB"     |
+  | 484   | "2017-03-27 14:42:34.097572Z"     | "9194A82EF4BB0123"     |
+  | 780   | "2017-03-27 14:42:34.097591Z"     | "BF92748B4AAAF14A"     |
+  ```
 
 *Pseudo*
 
-```elixir
-iex> Scribe.print(data, style: Scribe.Style.Pseudo)
+  ```elixir
+  iex> Scribe.print(data, style: Scribe.Style.Pseudo)
 
-┌───────┬───────────────────────────────────┬────────────────────────┐
-│ :id   │ :inserted_at                      │ :key                   │
-├───────┼───────────────────────────────────┼────────────────────────┤
-│ 457   │ "2017-03-27 14:42:34.095202Z"     │ "CEB0E055ECDF6028"     │
-│ 326   │ "2017-03-27 14:42:34.097519Z"     │ "CF67027F7235B88D"     │
-│ 756   │ "2017-03-27 14:42:34.097553Z"     │ "DE016DFF477BEDDB"     │
-│ 484   │ "2017-03-27 14:42:34.097572Z"     │ "9194A82EF4BB0123"     │
-│ 780   │ "2017-03-27 14:42:34.097591Z"     │ "BF92748B4AAAF14A"     │
-└───────┴───────────────────────────────────┴────────────────────────┘
-```
+  ┌───────┬───────────────────────────────────┬────────────────────────┐
+  │ :id   │ :inserted_at                      │ :key                   │
+  ├───────┼───────────────────────────────────┼────────────────────────┤
+  │ 457   │ "2017-03-27 14:42:34.095202Z"     │ "CEB0E055ECDF6028"     │
+  │ 326   │ "2017-03-27 14:42:34.097519Z"     │ "CF67027F7235B88D"     │
+  │ 756   │ "2017-03-27 14:42:34.097553Z"     │ "DE016DFF477BEDDB"     │
+  │ 484   │ "2017-03-27 14:42:34.097572Z"     │ "9194A82EF4BB0123"     │
+  │ 780   │ "2017-03-27 14:42:34.097591Z"     │ "BF92748B4AAAF14A"     │
+  └───────┴───────────────────────────────────┴────────────────────────┘
+  ```
 
-Set a default one in your Mix config, e.g. `config :scribe, style: Scribe.Style.Psql`
+Set a default one in your Mix config if you like:
+
+  ```elixir
+  config :scribe, style: Scribe.Style.Psql`
+  ```

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Pretty-print tables of Elixir structs and maps. Inspired by [hirb](https://githu
 
 ## Usage
 
-Use `Scribe.print/1` to print a list of maps or structs as a table.
-Header columns are taken from the keys of the first element.
+Print a list of maps or structs as a table. Header columns are taken from the
+keys of the first element.
 
   ```elixir
-  iex(1)> [%{key: "value", another_key: 123},
-  ...(1)> %{key: "test", another_key: :key}] |> Scribe.print
+  iex(1)> data = [%{key: "value", another_key: 123},
+  ...(1)> %{key: "test", another_key: :key}]
+  iex(2)> Scribe.print(data)
   +----------------+-------------+
   | :another_key   | :key        |
   +----------------+-------------+
@@ -53,7 +54,7 @@ Useful for printing large collections, such as results of database queries
 
 ## Use Scribe Automatically
 
-Scribe can override `inspect/2` to automatically return maps in table format.
+Scribe can override `Inspect` to automatically return maps in table format.
 Add the following to your `config/dev.exs`:
 
   ```elixir
@@ -62,16 +63,15 @@ Add the following to your `config/dev.exs`:
     auto_inspect: true
   ```
 
-If needed, it can be temporarily disabled in the shell.
+Temporarily disable in the shell if needed:
 
   ```elixir
   iex(1)> Scribe.auto_inspect(false)
-  iex(2)> %{id: 1234, key: :value}
-  %{id: 1234, key: :value}
+  :ok
   ```
 
-*Note: Auto-inspect functionality will not work in production Distillery
-releases. Leave it out of your prod.exs*
+**Note: Auto-inspect will not work in production Distillery
+releases. Leave it out of your prod.exs**
 
 ## Pagination
 
@@ -172,7 +172,7 @@ Pass a `width` option to define table width.
 
 ### Styles
 
-Scribe supports three styling formats natively, with support for custom adapters.
+Scribe supports four styling formats natively, with support for custom adapters.
 
 *Default*
 
@@ -237,5 +237,5 @@ Scribe supports three styling formats natively, with support for custom adapters
 Set a default one in your Mix config if you like:
 
   ```elixir
-  config :scribe, style: Scribe.Style.Psql`
+  config :scribe, style: Scribe.Style.Psql
   ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-# import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :scribe,
+  compile_auto_inspect: true,
+  auto_inspect: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :scribe,
+  compile_auto_inspect: true,
+  auto_inspect: true

--- a/inspect_overrides/1_5.ex
+++ b/inspect_overrides/1_5.ex
@@ -1,6 +1,6 @@
 if Scribe.compile_auto_inspect?() do
   import Kernel, except: [inspect: 1]
-  import Inspect.Algebra
+  import Inspect.Algebra, warn: false
 
   defimpl Inspect, for: List do
     def inspect([], opts) do

--- a/inspect_overrides/1_5.ex
+++ b/inspect_overrides/1_5.ex
@@ -20,7 +20,7 @@ if Scribe.compile_auto_inspect?() do
     end
 
     defp do_inspect?(term) do
-      Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled?()
+      Enum.any?(term, &(!is_map(&1))) or not Scribe.auto_inspect?()
     end
 
     # TODO: Remove :char_list and :as_char_lists handling in 2.0
@@ -154,7 +154,7 @@ if Scribe.compile_auto_inspect?() do
     end
 
     def inspect(map, name, opts) do
-      if Scribe.enabled?() do
+      if Scribe.auto_inspect?() do
         Scribe.format([map])
       else
         map = :maps.to_list(map)
@@ -192,7 +192,7 @@ if Scribe.compile_auto_inspect?() do
         dunder ->
           if :maps.keys(dunder) == :maps.keys(map) do
             pruned =
-              if Scribe.enabled?() do
+              if Scribe.auto_inspect?() do
                 :maps.remove(:__exception__, map)
               else
                 :maps.remove(:__exception__, :maps.remove(:__struct__, map))

--- a/inspect_overrides/1_5.ex
+++ b/inspect_overrides/1_5.ex
@@ -1,7 +1,7 @@
-import Kernel, except: [inspect: 1]
-import Inspect.Algebra
-
 if Scribe.compile_auto_inspect?() do
+  import Kernel, except: [inspect: 1]
+  import Inspect.Algebra
+
   defimpl Inspect, for: List do
     def inspect([], opts) do
       color("[]", :list, opts)

--- a/inspect_overrides/1_5.ex
+++ b/inspect_overrides/1_5.ex
@@ -1,161 +1,214 @@
 import Kernel, except: [inspect: 1]
 import Inspect.Algebra
 
-defimpl Inspect, for: List do
-  def inspect([], opts) do
-    color("[]", :list, opts)
-  end
-
-  def inspect([head | _rest] = term, opts) when is_map(head) do
-    if Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled? do
-      do_inspect(term, opts)
-    else
-      Scribe.format(term)
+if Scribe.compile_auto_inspect?() do
+  defimpl Inspect, for: List do
+    def inspect([], opts) do
+      color("[]", :list, opts)
     end
-  end
-  def inspect(term, opts) do
-    do_inspect(term, opts)
-  end
 
-  # TODO: Remove :char_list and :as_char_lists handling in 2.0
-  def do_inspect(term, opts) do
-    %Inspect.Opts{charlists: lists, char_lists: lists_deprecated, printable_limit: printable_limit} = opts
-    lists =
-      if lists == :infer and lists_deprecated != :infer do
-        case lists_deprecated do
-          :as_char_lists ->
-            IO.warn "the :char_lists inspect option and its :as_char_lists " <>
-              "value are deprecated, use the :charlists option and its " <>
-              ":as_charlists value instead"
-            :as_charlists
-          _ ->
-            IO.warn "the :char_lists inspect option is deprecated, use :charlists instead"
-            lists_deprecated
-        end
+    def inspect([head | _rest] = term, opts) when is_map(head) do
+      if do_inspect?(term) do
+        do_inspect(term, opts)
       else
-        lists
+        Scribe.format(term)
       end
-    open = color("[", :list, opts)
-    sep = color(",", :list, opts)
-    close = color("]", :list, opts)
+    end
 
-    cond do
-      lists == :as_charlists or (lists == :infer and printable?(term, printable_limit)) ->
-        inspected =
-          case Inspect.BitString.escape(IO.chardata_to_string(term), ?', printable_limit) do
-            {escaped, ""} -> [?', escaped, ?']
-            {escaped, _} -> [?', escaped, ?', " ++ ..."]
+    def inspect(term, opts) do
+      do_inspect(term, opts)
+    end
+
+    defp do_inspect?(term) do
+      Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled?()
+    end
+
+    # TODO: Remove :char_list and :as_char_lists handling in 2.0
+    def do_inspect(term, opts) do
+      %Inspect.Opts{
+        charlists: lists,
+        char_lists: lists_deprecated,
+        printable_limit: printable_limit
+      } = opts
+
+      lists =
+        if lists == :infer and lists_deprecated != :infer do
+          case lists_deprecated do
+            :as_char_lists ->
+              IO.warn(
+                "the :char_lists inspect option and its :as_char_lists " <>
+                  "value are deprecated, use the :charlists option and its " <>
+                  ":as_charlists value instead"
+              )
+
+              :as_charlists
+
+            _ ->
+              IO.warn(
+                "the :char_lists inspect option is deprecated, use :charlists instead"
+              )
+
+              lists_deprecated
           end
-        IO.iodata_to_binary inspected
-      keyword?(term) ->
-        surround_many(open, term, close, opts, &keyword/2, sep)
-      true ->
-        surround_many(open, term, close, opts, &to_doc/2, sep)
-    end
-  end
-
-  @doc false
-  def keyword({key, value}, opts) do
-    key = color(key_to_binary(key) <> ": ", :atom, opts)
-    concat(key, to_doc(value, opts))
-  end
-
-  @doc false
-  def keyword?([{key, _value} | rest]) when is_atom(key) do
-    case Atom.to_charlist(key) do
-      'Elixir.' ++ _ -> false
-      _ -> keyword?(rest)
-    end
-  end
-
-  def keyword?([]),     do: true
-  def keyword?(_other), do: false
-
-  @doc false
-  def printable?(list), do: printable?(list, :infinity)
-
-  @doc false
-  def printable?(_, 0), do: true
-  def printable?([char | rest], counter) when char in 32..126, do: printable?(rest, decrement(counter))
-  def printable?([?\n | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\r | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\t | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\v | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\b | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\f | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\e | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([?\a | rest], counter), do: printable?(rest, decrement(counter))
-  def printable?([], _counter), do: true
-  def printable?(_, _counter), do: false
-
-  @compile {:inline, decrement: 1}
-  defp decrement(:infinity), do: :infinity
-  defp decrement(counter),   do: counter - 1
-
-  ## Private
-
-  defp key_to_binary(key) do
-    case Inspect.Atom.inspect(key) do
-      ":" <> right -> right
-      other -> other
-    end
-  end
-end
-
-defimpl Inspect, for: Map do
-  def inspect(map, opts) do
-    nest inspect(map, "", opts), 1
-  end
-
-  def inspect(map, name, opts) do
-    if Scribe.enabled? do
-      Scribe.format([map])
-    else
-      map = :maps.to_list(map)
-      open = color("%" <> name <> "{", :map, opts)
-      sep = color(",", :map, opts)
-      close = color("}", :map, opts)
-      surround_many(open, map, close, opts, traverse_fun(map, opts), sep)
-    end
-  end
-
-  defp traverse_fun(list, opts) do
-    if Inspect.List.keyword?(list) do
-      &Inspect.List.keyword/2
-    else
-      sep = color(" => ", :map, opts)
-      &to_map(&1, &2, sep)
-    end
-  end
-
-  defp to_map({key, value}, opts, sep) do
-    concat(
-      concat(to_doc(key, opts), sep),
-      to_doc(value, opts)
-    )
-  end
-end
-
-defimpl Inspect, for: Any do
-  def inspect(%{__struct__: struct} = map, opts) do
-    try do
-      struct.__struct__
-    rescue
-      _ -> Inspect.Map.inspect(map, opts)
-    else
-      dunder ->
-        if :maps.keys(dunder) == :maps.keys(map) do
-          pruned =
-            if Scribe.enabled? do
-              :maps.remove(:__exception__, map)
-            else
-              :maps.remove(:__exception__, :maps.remove(:__struct__, map))
-            end
-          colorless_opts = %{opts | syntax_colors: []}
-          Inspect.Map.inspect(pruned, Inspect.Atom.inspect(struct, colorless_opts), opts)
         else
-          Inspect.Map.inspect(map, opts)
+          lists
         end
+
+      open = color("[", :list, opts)
+      sep = color(",", :list, opts)
+      close = color("]", :list, opts)
+
+      cond do
+        lists == :as_charlists or
+            (lists == :infer and printable?(term, printable_limit)) ->
+          inspected =
+            case Inspect.BitString.escape(
+                   IO.chardata_to_string(term),
+                   ?',
+                   printable_limit
+                 ) do
+              {escaped, ""} -> [?', escaped, ?']
+              {escaped, _} -> [?', escaped, ?', " ++ ..."]
+            end
+
+          IO.iodata_to_binary(inspected)
+
+        keyword?(term) ->
+          surround_many(open, term, close, opts, &keyword/2, sep)
+
+        true ->
+          surround_many(open, term, close, opts, &to_doc/2, sep)
+      end
+    end
+
+    @doc false
+    def keyword({key, value}, opts) do
+      key = color(key_to_binary(key) <> ": ", :atom, opts)
+      concat(key, to_doc(value, opts))
+    end
+
+    @doc false
+    def keyword?([{key, _value} | rest]) when is_atom(key) do
+      case Atom.to_charlist(key) do
+        'Elixir.' ++ _ -> false
+        _ -> keyword?(rest)
+      end
+    end
+
+    def keyword?([]), do: true
+    def keyword?(_other), do: false
+
+    @doc false
+    def printable?(list), do: printable?(list, :infinity)
+
+    @doc false
+    def printable?(_, 0), do: true
+
+    def printable?([char | rest], counter) when char in 32..126,
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\n | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\r | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\t | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\v | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\b | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\f | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\e | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([?\a | rest], counter),
+      do: printable?(rest, decrement(counter))
+
+    def printable?([], _counter), do: true
+    def printable?(_, _counter), do: false
+
+    @compile {:inline, decrement: 1}
+    defp decrement(:infinity), do: :infinity
+    defp decrement(counter), do: counter - 1
+
+    ## Private
+
+    defp key_to_binary(key) do
+      case Inspect.Atom.inspect(key) do
+        ":" <> right -> right
+        other -> other
+      end
+    end
+  end
+
+  defimpl Inspect, for: Map do
+    def inspect(map, opts) do
+      nest(inspect(map, "", opts), 1)
+    end
+
+    def inspect(map, name, opts) do
+      if Scribe.enabled?() do
+        Scribe.format([map])
+      else
+        map = :maps.to_list(map)
+        open = color("%" <> name <> "{", :map, opts)
+        sep = color(",", :map, opts)
+        close = color("}", :map, opts)
+        surround_many(open, map, close, opts, traverse_fun(map, opts), sep)
+      end
+    end
+
+    defp traverse_fun(list, opts) do
+      if Inspect.List.keyword?(list) do
+        &Inspect.List.keyword/2
+      else
+        sep = color(" => ", :map, opts)
+        &to_map(&1, &2, sep)
+      end
+    end
+
+    defp to_map({key, value}, opts, sep) do
+      concat(
+        concat(to_doc(key, opts), sep),
+        to_doc(value, opts)
+      )
+    end
+  end
+
+  defimpl Inspect, for: Any do
+    def inspect(%{__struct__: struct} = map, opts) do
+      try do
+        struct.__struct__
+      rescue
+        _ -> Inspect.Map.inspect(map, opts)
+      else
+        dunder ->
+          if :maps.keys(dunder) == :maps.keys(map) do
+            pruned =
+              if Scribe.enabled?() do
+                :maps.remove(:__exception__, map)
+              else
+                :maps.remove(:__exception__, :maps.remove(:__struct__, map))
+              end
+
+            colorless_opts = %{opts | syntax_colors: []}
+
+            Inspect.Map.inspect(
+              pruned,
+              Inspect.Atom.inspect(struct, colorless_opts),
+              opts
+            )
+          else
+            Inspect.Map.inspect(map, opts)
+          end
+      end
     end
   end
 end

--- a/inspect_overrides/1_6.ex
+++ b/inspect_overrides/1_6.ex
@@ -1,6 +1,6 @@
 if Scribe.compile_auto_inspect?() do
   import Kernel, except: [inspect: 1]
-  import Inspect.Algebra
+  import Inspect.Algebra, warn: false
 
   defimpl Inspect, for: List do
     alias Code.Identifier

--- a/inspect_overrides/1_6.ex
+++ b/inspect_overrides/1_6.ex
@@ -1,7 +1,7 @@
-import Kernel, except: [inspect: 1]
-import Inspect.Algebra
-
 if Scribe.compile_auto_inspect?() do
+  import Kernel, except: [inspect: 1]
+  import Inspect.Algebra
+
   defimpl Inspect, for: List do
     alias Code.Identifier
 

--- a/inspect_overrides/1_6.ex
+++ b/inspect_overrides/1_6.ex
@@ -22,7 +22,7 @@ if Scribe.compile_auto_inspect?() do
     end
 
     defp do_inspect?(term) do
-      Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled?()
+      Enum.any?(term, &(!is_map(&1))) or not Scribe.auto_inspect?()
     end
 
     def do_inspect(term, opts) do
@@ -116,7 +116,7 @@ if Scribe.compile_auto_inspect?() do
     end
 
     def inspect(map, name, opts) do
-      if Scribe.enabled?() do
+      if Scribe.auto_inspect?() do
         Scribe.format([map])
       else
         map = :maps.to_list(map)
@@ -160,7 +160,7 @@ if Scribe.compile_auto_inspect?() do
         dunder ->
           if :maps.keys(dunder) == :maps.keys(struct) do
             pruned =
-              if Scribe.enabled?() do
+              if Scribe.auto_inspect?() do
                 :maps.remove(:__exception__, struct)
               else
                 :maps.remove(:__exception__, :maps.remove(:__struct__, struct))

--- a/inspect_overrides/1_6.ex
+++ b/inspect_overrides/1_6.ex
@@ -1,143 +1,182 @@
 import Kernel, except: [inspect: 1]
 import Inspect.Algebra
 
-defimpl Inspect, for: List do
-  alias Code.Identifier
+if Scribe.compile_auto_inspect?() do
+  defimpl Inspect, for: List do
+    alias Code.Identifier
 
-  def inspect([], opts) do
-    color("[]", :list, opts)
-  end
-  def inspect([head | _rest] = term, opts) when is_map(head) do
-    if Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled? do
-      do_inspect(term, opts)
-    else
-      Scribe.format(term)
+    def inspect([], opts) do
+      color("[]", :list, opts)
     end
-  end
-  def inspect(term, opts) do
-    do_inspect(term, opts)
-  end
 
-  def do_inspect(term, opts) do
-    %Inspect.Opts{
-      charlists: lists,
-      char_lists: lists_deprecated,
-      printable_limit: printable_limit
-    } = opts
-
-    lists =
-      if lists == :infer and lists_deprecated != :infer do
-        case lists_deprecated do
-          :as_char_lists ->
-            IO.warn(
-              "the :char_lists inspect option and its :as_char_lists " <>
-                "value are deprecated, use the :charlists option and its " <>
-                ":as_charlists value instead"
-            )
-
-            :as_charlists
-
-          _ ->
-            IO.warn("the :char_lists inspect option is deprecated, use :charlists instead")
-            lists_deprecated
-        end
+    def inspect([head | _rest] = term, opts) when is_map(head) do
+      if do_inspect?(term) do
+        do_inspect(term, opts)
       else
-        lists
+        Scribe.format(term)
       end
+    end
 
-    open = color("[", :list, opts)
-    sep = color(",", :list, opts)
-    close = color("]", :list, opts)
+    def inspect(term, opts) do
+      do_inspect(term, opts)
+    end
 
-    cond do
-      lists == :as_charlists or (lists == :infer and List.ascii_printable?(term, printable_limit)) ->
-        inspected =
-          case Identifier.escape(IO.chardata_to_string(term), ?', printable_limit) do
-            {escaped, ""} -> [?', escaped, ?']
-            {escaped, _} -> [?', escaped, ?', " ++ ..."]
+    defp do_inspect?(term) do
+      Enum.any?(term, &(!is_map(&1))) or not Scribe.enabled?()
+    end
+
+    def do_inspect(term, opts) do
+      %Inspect.Opts{
+        charlists: lists,
+        char_lists: lists_deprecated,
+        printable_limit: printable_limit
+      } = opts
+
+      lists =
+        if lists == :infer and lists_deprecated != :infer do
+          case lists_deprecated do
+            :as_char_lists ->
+              IO.warn(
+                "the :char_lists inspect option and its :as_char_lists " <>
+                  "value are deprecated, use the :charlists option and its " <>
+                  ":as_charlists value instead"
+              )
+
+              :as_charlists
+
+            _ ->
+              IO.warn(
+                "the :char_lists inspect option is deprecated, use :charlists instead"
+              )
+
+              lists_deprecated
           end
-
-        IO.iodata_to_binary(inspected)
-
-      keyword?(term) ->
-        container_doc(open, term, close, opts, &keyword/2, separator: sep, break: :strict)
-
-      true ->
-        container_doc(open, term, close, opts, &to_doc/2, separator: sep)
-    end
-  end
-
-  @doc false
-  def keyword({key, value}, opts) do
-    key = color(Identifier.inspect_as_key(key), :atom, opts)
-    concat(key, concat(" ", to_doc(value, opts)))
-  end
-
-  @doc false
-  def keyword?([{key, _value} | rest]) when is_atom(key) do
-    case Atom.to_charlist(key) do
-      'Elixir.' ++ _ -> false
-      _ -> keyword?(rest)
-    end
-  end
-
-  def keyword?([]), do: true
-  def keyword?(_other), do: false
-end
-
-defimpl Inspect, for: Map do
-  import Inspect.Algebra
-
-  def inspect(map, opts) do
-    inspect(map, "", opts)
-  end
-
-  def inspect(map, name, opts) do
-    if Scribe.enabled? do
-      Scribe.format([map])
-    else
-      map = :maps.to_list(map)
-      open = color("%" <> name <> "{", :map, opts)
-      sep = color(",", :map, opts)
-      close = color("}", :map, opts)
-      container_doc(open, map, close, opts, traverse_fun(map, opts), separator: sep, break: :strict)
-    end
-  end
-
-  defp traverse_fun(list, opts) do
-    if Inspect.List.keyword?(list) do
-      &Inspect.List.keyword/2
-    else
-      sep = color(" => ", :map, opts)
-      &to_map(&1, &2, sep)
-    end
-  end
-
-  defp to_map({key, value}, opts, sep) do
-    concat(concat(to_doc(key, opts), sep), to_doc(value, opts))
-  end
-end
-
-defimpl Inspect, for: Any do
-  def inspect(%module{} = struct, opts) do
-    try do
-      module.__struct__
-    rescue
-      _ -> Inspect.Map.inspect(struct, opts)
-    else
-      dunder ->
-        if :maps.keys(dunder) == :maps.keys(struct) do
-          pruned =
-            if Scribe.enabled? do
-              :maps.remove(:__exception__, struct)
-            else
-              :maps.remove(:__exception__, :maps.remove(:__struct__, struct))
-            end
-          colorless_opts = %{opts | syntax_colors: []}
-          Inspect.Map.inspect(pruned, Inspect.Atom.inspect(module, colorless_opts), opts)
         else
-          Inspect.Map.inspect(struct, opts)
+          lists
         end
+
+      open = color("[", :list, opts)
+      sep = color(",", :list, opts)
+      close = color("]", :list, opts)
+
+      cond do
+        lists == :as_charlists or
+            (lists == :infer and List.ascii_printable?(term, printable_limit)) ->
+          inspected =
+            case Identifier.escape(
+                   IO.chardata_to_string(term),
+                   ?',
+                   printable_limit
+                 ) do
+              {escaped, ""} -> [?', escaped, ?']
+              {escaped, _} -> [?', escaped, ?', " ++ ..."]
+            end
+
+          IO.iodata_to_binary(inspected)
+
+        keyword?(term) ->
+          container_doc(
+            open,
+            term,
+            close,
+            opts,
+            &keyword/2,
+            separator: sep,
+            break: :strict
+          )
+
+        true ->
+          container_doc(open, term, close, opts, &to_doc/2, separator: sep)
+      end
+    end
+
+    @doc false
+    def keyword({key, value}, opts) do
+      key = color(Identifier.inspect_as_key(key), :atom, opts)
+      concat(key, concat(" ", to_doc(value, opts)))
+    end
+
+    @doc false
+    def keyword?([{key, _value} | rest]) when is_atom(key) do
+      case Atom.to_charlist(key) do
+        'Elixir.' ++ _ -> false
+        _ -> keyword?(rest)
+      end
+    end
+
+    def keyword?([]), do: true
+    def keyword?(_other), do: false
+  end
+
+  defimpl Inspect, for: Map do
+    import Inspect.Algebra
+
+    def inspect(map, opts) do
+      inspect(map, "", opts)
+    end
+
+    def inspect(map, name, opts) do
+      if Scribe.enabled?() do
+        Scribe.format([map])
+      else
+        map = :maps.to_list(map)
+        open = color("%" <> name <> "{", :map, opts)
+        sep = color(",", :map, opts)
+        close = color("}", :map, opts)
+
+        container_doc(
+          open,
+          map,
+          close,
+          opts,
+          traverse_fun(map, opts),
+          separator: sep,
+          break: :strict
+        )
+      end
+    end
+
+    defp traverse_fun(list, opts) do
+      if Inspect.List.keyword?(list) do
+        &Inspect.List.keyword/2
+      else
+        sep = color(" => ", :map, opts)
+        &to_map(&1, &2, sep)
+      end
+    end
+
+    defp to_map({key, value}, opts, sep) do
+      concat(concat(to_doc(key, opts), sep), to_doc(value, opts))
+    end
+  end
+
+  defimpl Inspect, for: Any do
+    def inspect(%module{} = struct, opts) do
+      try do
+        module.__struct__
+      rescue
+        _ -> Inspect.Map.inspect(struct, opts)
+      else
+        dunder ->
+          if :maps.keys(dunder) == :maps.keys(struct) do
+            pruned =
+              if Scribe.enabled?() do
+                :maps.remove(:__exception__, struct)
+              else
+                :maps.remove(:__exception__, :maps.remove(:__struct__, struct))
+              end
+
+            colorless_opts = %{opts | syntax_colors: []}
+
+            Inspect.Map.inspect(
+              pruned,
+              Inspect.Atom.inspect(module, colorless_opts),
+              opts
+            )
+          else
+            Inspect.Map.inspect(struct, opts)
+          end
+      end
     end
   end
 end

--- a/lib/scribe.ex
+++ b/lib/scribe.ex
@@ -25,14 +25,6 @@ defmodule Scribe do
           width: integer
         ]
 
-  def enable do
-    Application.put_env(:scribe, :enable, true)
-  end
-
-  def disable do
-    Application.put_env(:scribe, :enable, false)
-  end
-
   @doc ~S"""
   Returns true if Scribe is overriding `Inspect`.
 
@@ -42,7 +34,13 @@ defmodule Scribe do
       true
   """
   def enabled? do
-    Application.get_env(:scribe, :enable, true)
+    compile_auto_inspect?() and
+      Application.get_env(:scribe, :auto_inspect, true)
+  end
+
+  @doc false
+  def compile_auto_inspect? do
+    Application.get_env(:scribe, :compile_auto_inspect, false)
   end
 
   @doc ~S"""

--- a/lib/scribe.ex
+++ b/lib/scribe.ex
@@ -26,16 +26,32 @@ defmodule Scribe do
         ]
 
   @doc ~S"""
+  Enables/disables auto-inspect override.
+
+  If true, Scribe will override `inspect/2` for maps and structs, printing
+  them as tables.
+
+  ## Examples
+
+      iex> Scribe.auto_inspect(true)
+      :ok
+  """
+  @spec auto_inspect(boolean) :: :ok
+  def auto_inspect(inspect?) do
+    Application.put_env(:scribe, :auto_inspect, inspect?)
+  end
+
+  @doc ~S"""
   Returns true if Scribe is overriding `Inspect`.
 
   ## Examples
 
-      iex> Scribe.enabled?
+      iex> Scribe.auto_inspect?
       true
   """
-  def enabled? do
+  def auto_inspect? do
     compile_auto_inspect?() and
-      Application.get_env(:scribe, :auto_inspect, true)
+      Application.get_env(:scribe, :auto_inspect, false)
   end
 
   @doc false
@@ -61,6 +77,7 @@ defmodule Scribe do
   """
   @spec print(data, format_opts) :: :ok
   def print(_results, opts \\ [])
+
   def print([], _opts), do: :ok
 
   def print(results, opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Scribe.Mixfile do
   def project do
     [
       app: :scribe,
-      version: "0.7.0",
+      version: "0.8.0",
       elixir: "~> 1.5",
       source_url: "https://github.com/codedge-llc/scribe",
       description: description(),

--- a/test/inspect_overrides_test.exs
+++ b/test/inspect_overrides_test.exs
@@ -3,10 +3,6 @@ defmodule Scribe.InspectOverridesTest do
 
   use ExUnit.Case, async: false
 
-  def set_auto_inspect(enabled?) do
-    Application.put_env(:scribe, :auto_inspect, enabled?)
-  end
-
   def set_compile_auto_inspect(enabled?) do
     Application.put_env(:scribe, :compile_auto_inspect, enabled?)
   end
@@ -88,7 +84,7 @@ defmodule Scribe.InspectOverridesTest do
     assert inspect([t, t, t]) == expected
   end
 
-  test "Scribe.enabled? returns correct status for config options" do
+  test "Scribe.auto_inspect? returns correct status for config options" do
     # {:compile_auto_inspect, :auto_inspect, Scribe.enabled?()}
     [
       {true, true, true},
@@ -98,14 +94,14 @@ defmodule Scribe.InspectOverridesTest do
     ]
     |> Enum.each(fn {compile?, enable?, result} ->
       set_compile_auto_inspect(compile?)
-      set_auto_inspect(enable?)
-      assert Scribe.enabled?() == result
+      Scribe.auto_inspect(enable?)
+      assert Scribe.auto_inspect?() == result
     end)
 
     on_exit(fn -> set_config(true) end)
   end
 
-  test "formatting is used when Scribe.enabled?()" do
+  test "formatting is used when Scribe.auto_inspect?()" do
     set_config(false)
 
     t = %{test: 1234, key: "testing"}

--- a/test/scribe_test.exs
+++ b/test/scribe_test.exs
@@ -1,7 +1,7 @@
 defmodule Scribe.ScribeTest do
   defstruct id: nil, value: 1234
 
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureIO
 
@@ -197,7 +197,7 @@ defmodule Scribe.ScribeTest do
 
   test "Scribe.inspect/2 returns original data" do
     val = %{test: 1234}
-    fun = fn -> Scribe.inspect(val) end
-    assert capture_io(fun) == inspect(val) <> "\n"
+    fun = fn -> assert Scribe.inspect(val) == val end
+    capture_io(fun)
   end
 end


### PR DESCRIPTION
Set them in your Mix.Config

If the first is false, inspect overrides will not be compiled. If
compiled and the second is false, inspect override will not be triggered
until it is set to true.

Would like to hook into inspect opts with `scribe: false` but opts are
always passed as a struct. Perhaps might use `pretty: false` instead.