### PR TITLE
Update README to colorize format opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Pass a `width` option to define table width.
 ### Disable Colors
 
   ```elixir
-  iex> Scribe.print(data, colorization: false)
+  iex> Scribe.print(data, colorize: false)
   ```
 
 ### Styles


### PR DESCRIPTION
I discovered that colorization didn't work, and colorize is the defined opt name in the typespec