### PR TITLE
Two minor fixes to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ keys of the first element.
 
   ```elixir
   iex(1)> data = [%{key: "value", another_key: 123},
-  ...(1)> %{key: "test", another_key: :key}]
+  ...(1)> [%{key: "test", another_key: :key}]
   iex(2)> Scribe.print(data)
   +----------------+-------------+
   | :another_key   | :key        |
@@ -130,7 +130,7 @@ You can specify functions that take the given row's struct or map as its only ar
     User
     |> limit(5)
     |> Repo.all
-    |> Scribe.print(u, [{"ID", :id}, {"Full Name", fn(x) -> "#{x.last_name}, #{x.first_name}" end}])
+    |> Scribe.print(data: [{"ID", :id}, {"Full Name", fn(x) -> "#{x.last_name}, #{x.first_name}" end}])
 
   +--------------------------+----------------------------------------------+
   | "ID"                     | "Full Name"                                  |


### PR DESCRIPTION
Ahoy!

I made a couple small fixes to the `readme`, the one missing the `:data` keyword kept biting me in the ass whenever I'd go to read this doc; so, I figured it's about damn time I fixed it :) and the other was just something _very minor_ my eyes caught.

Please let me know if there's anything I need to change.

Thank you for your time.

------------------

Details

    * Added missing opening bracket
    * Fixed example with column function